### PR TITLE
figured a way to get invalid utf 8 chars to read

### DIFF
--- a/dog/Cargo.toml
+++ b/dog/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 clap = "2.33"
+encoding_rs = "0.8.32"
+encoding_rs_io = "0.1.7"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/dog/example.txt
+++ b/dog/example.txt
@@ -1,0 +1,10 @@
+The bustle in a house$
+The morning after death$
+Is solemnest of industries$
+Enacted upon earth,�M-^@M-^T$
+Enacted upon earth,M-bM-^@M-^T$
+$
+The sweeping up the heart,$
+And putting love away$
+We shall not want to use again$
+Until eternity.$

--- a/dog/src/lib.rs
+++ b/dog/src/lib.rs
@@ -1,9 +1,10 @@
 use clap::{App, Arg};
+use encoding_rs::UTF_8;
+use encoding_rs_io::DecodeReaderBytesBuilder;
 use std::error::Error;
 use std::fs::File;
-use std::io::{self, BufRead, BufReader};
-use encoding_rs::WINDOWS_1252;
-use encoding_rs_io::DecodeReaderBytesBuilder;
+use std::io::{self, BufRead, BufReader, Read};
+use std::str;
 
 type MyResult<T> = Result<T, Box<dyn Error>>;
 
@@ -22,37 +23,101 @@ pub fn run(config: Config) -> MyResult<()> {
             Err(err) => eprintln!("Failed to open {}: {}", filename, err),
             Ok(file) => {
                 let mut cnt = 0;
-                for line_result in file.lines() {
-                    // check if line contains valid utf-8
-                    match line_result {
-                        Ok(line) => {
-                            cnt += 1;
-                            if config.number_lines {
-                                println!("{:>6}\t{}", cnt, line);
-                            } else if config.number_nonblank_lines {
-                                if line.is_empty() {
-                                    println!("{}", line);
-                                    cnt -= 1;
-                                } else {
-                                    println!("{:>6}\t{}", cnt, line);
-                                }
-                            } else if config.display_d {
-                                // line.u
-                                println!("{}$", line);
+
+                if config.display_d {
+                    let reader = Box::new(BufReader::new(File::open(filename).unwrap()));
+                    let mut line_of_bytes: Vec<u8> = vec![];
+                    for byte_result in reader.bytes() {
+                        let byte = byte_result.unwrap();
+                        if byte >= 32 {
+                            if byte < 127 {
+                                line_of_bytes.push(byte);
+                            } else if byte == 127 {
+                                line_of_bytes.push(b'^');
+                                line_of_bytes.push(b'?');
                             } else {
-                                println!("{}", line);
+                                line_of_bytes.push(b'M');
+                                line_of_bytes.push(b'-');
+                                if byte >= 128 + 32 {
+                                    if byte < 128 + 127 {
+                                        line_of_bytes.push(byte - 128);
+                                    } else {
+                                        line_of_bytes.push(b'^');
+                                        line_of_bytes.push(b'?');
+                                    }
+                                } else {
+                    println!("{}", byte);
+                                    line_of_bytes.push(b'^');
+                                    line_of_bytes.push(byte - 128 + 64);
+                                }
                             }
+                        } else if byte == b'\t' {
+                            line_of_bytes.push(b'\t');
+                        } else if byte == b'\n' {
+                            line_of_bytes.push(b'\n');
+                            // break;
+                        } else {
+                            line_of_bytes.push(b'^');
+                            line_of_bytes.push(byte + 64);
                         }
-                        // line contains invalid utf-8
-                        Err(err) => {
-                            let file = File::open(filename.clone())?;
-                            let mut reader = BufReader::new(
-                                DecodeReaderBytesBuilder::new()
-                                    .encoding(Some(WINDOWS_1252))
-                                    .build(file),
-                            );
-                            for line in reader.lines() {
-                                println!("{:?}", line?);
+                    }
+                    // let mut line_of_bytes: Vec<u8> = vec![];
+                    // for byte_result in reader.bytes() {
+                    //     let byte = byte_result.unwrap();
+                    //     // println!("{}$", byte.is_ascii());
+                    //     if byte.is_ascii() {
+                    //         line_of_bytes.push(byte);
+                    //     } else {
+                    //         if byte == 127 {
+                    //             line_of_bytes.push(b'^');
+                    //             line_of_bytes.push(b'?');
+                    //         } else {
+                    //             line_of_bytes.push(b'M');
+                    //             line_of_bytes.push(b'-');
+                    //             if byte >= 128 + 32 {
+                    //                 if byte < 128 + 127 {
+                    //                     line_of_bytes.push(byte - 128);
+                    //                 } else {
+                    //                     line_of_bytes.push(b'^');
+                    //                     line_of_bytes.push(b'?');
+                    //                 }
+                    //             } else {
+                    //                 line_of_bytes.push(b'^');
+                    //                 line_of_bytes.push(byte - 128 + 64);
+                    //             }
+                    //         }
+                    //     }
+                    // }
+                    let s = match String::from_utf8(line_of_bytes) {
+                        Ok(v) => v,
+                        Err(e) => panic!("Invalid UTF-8 sequence: {}", e),
+                    };
+
+                    for line in s.lines() {
+                        println!("{}$", line);
+                    }
+                } else {
+                    for line_result in file.lines() {
+                        // check if line contains valid utf-8
+                        match line_result {
+                            Ok(line) => {
+                                cnt += 1;
+                                if config.number_lines {
+                                    println!("{:>6}\t{}", cnt, line);
+                                } else if config.number_nonblank_lines {
+                                    if line.is_empty() {
+                                        println!("{}", line);
+                                        cnt -= 1;
+                                    } else {
+                                        println!("{:>6}\t{}", cnt, line);
+                                    }
+                                } else {
+                                    println!("{}", line);
+                                }
+                            }
+                            // line contains invalid utf-8
+                            Err(err) => {
+                                println!("Error: {}", err);
                             }
                         }
                     }
@@ -114,3 +179,6 @@ pub fn get_args() -> MyResult<Config> {
         display_d: matches.is_present("display_d"),
     })
 }
+// Hey everyone!
+// I am currently following a book named Command Line Rust, I am currently trying to build a rust version of cat.
+// I am c  urrently trying to add a "new feature" to the book provided solution.

--- a/dog/src/main.rs
+++ b/dog/src/main.rs
@@ -1,3 +1,4 @@
+
 fn main() {
     if let Err(e) = dog::get_args().and_then(dog::run) {
         eprintln!("{}", e);


### PR DESCRIPTION
Added -e option for single files 

Integration tests are still failing due to cat -e producing different utf-8 or byte code 